### PR TITLE
Update DecoderRNN.py

### DIFF
--- a/las.pytorch/models/DecoderRNN.py
+++ b/las.pytorch/models/DecoderRNN.py
@@ -46,16 +46,13 @@ class DecoderRNN(nn.Module):
                                  batch_first=True, dropout=dropout_p, bidirectional=self.bidirectional_decoder)
 
         self.embedding = nn.Embedding(self.vocab_size, self.hidden_size)
-        self.input_dropout == nn.Dropout(self.dropout_p)
+        self.input_dropout = nn.Dropout(self.dropout_p)
         
         self.attention = Attention(dec_dim=self.hidden_size, enc_dim=self.encoder_output_size, conv_dim=1, attn_dim=self.hidden_size)
         self.fc = nn.Linear(self.hidden_size + self.encoder_output_size, self.output_size)
 
 
     def forward_step(self, input_var, hidden, encoder_outputs, context, attn_w, function):
-        if self.training:
-            self.rnn.flatten_parameters()
-
         batch_size = input_var.size(0)
         dec_len = input_var.size(1)
         enc_len = encoder_outputs.size(1)


### PR DESCRIPTION
Fixed misspelling in DecoderRNN.py.
Fixed memory leaks by delete 'self.rnn.flatten_parameters()' in forward_step().